### PR TITLE
fix: 스킵 시 누적 칸 또한 직전 라운드의 마지막 상태로 업데이트

### DIFF
--- a/services/gameService.js
+++ b/services/gameService.js
@@ -1058,6 +1058,15 @@ module.exports = {
               'Bowl factory',
               'Basket factory',
             ],
+            woodAccumulated: 5,
+            sandAccumulated: 4,
+            reedAccumulated: 0,
+            foodAccumulated: 0,
+            sheepAccumulated: 0,
+            stoneAccumulatedWest: 2,
+            pigAccumulated: 0,
+            cowAccumulated: 0,
+            stoneAccumulatedEast: 0,
           },
           {
             where: {
@@ -1201,6 +1210,15 @@ module.exports = {
               'Bowl factory',
               'Basket factory',
             ],
+            woodAccumulated: 5,
+            sandAccumulated: 3,
+            reedAccumulated: 6,
+            foodAccumulated: 1,
+            sheepAccumulated: 4,
+            stoneAccumulatedWest: 4,
+            pigAccumulated: 0,
+            cowAccumulated: 0,
+            stoneAccumulatedEast: 3,
           },
           {
             where: {


### PR DESCRIPTION
## Summary
스킵 시 누적 칸 업데이트가 빠져있어,  해당 부분 추가

## Describe your changes
각각 7라운드, 13라운드의 마지막 누적칸 상태로 업데이트, 노션의 `Propotype Scenario` 확인

## Issue number and link

@BaeGayeon 별 거 아니니 그냥 바로 마스터에 머지하겠음. 그냥 내용 공유는 필요할 거 같아서 언급은 해놓을게.