### PR TITLE
fix: P2 나무 개수 수정

### DIFF
--- a/services/gameService.js
+++ b/services/gameService.js
@@ -1143,7 +1143,7 @@ module.exports = {
               sheep: 0,
               pig: 0,
               cow: 0,
-              wood: 2,
+              wood: 1,
               fence: 7,
               cage: 1,
               cageArea: 3,


### PR DESCRIPTION
## Summary
8라운드로 건너뛸 시, P2의 나무 개수가 잘못돼 해당 부분 수정함

## Describe your changes
나무 2개 -> 나무 1개

## Issue number and link
